### PR TITLE
feat/Update CSS to prevent overflow on username and steps paragraph

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -14,9 +14,9 @@
         <section class="left-section">
           <section class="first-row-left" id="stepsBox">
               <h1 class="titles">Steps</h1>
-              <p id="totalSteps"></p>
-              <p id="averageUsersSteps"></p>
-              <p id="stepComparison"></p>
+              <p class="steps-text" id="totalSteps"></p>
+              <p class="steps-text" id="averageUsersSteps"></p>
+              <p class="steps-text" id="stepComparison"></p>
               <canvas id="stepChart"></canvas>
           </section>
           <section class="first-row-left" id="waterBox">
@@ -48,23 +48,12 @@
       </aside>
       <aside class="main-row" id="rightMainRow">
         <h1 id="username"> Username </h1>
-        <article>
-          <header>
-              <button class="toggleButton">
-                <h3 class="arrow">&#x25BA;    User Info:</h3> 
-                <h3 class="user-info hidden"></h3>
-              </button>
-          </header>
-        </article>
-        <section class="right-section">
-          <section class="second-row-right"></section>
-        </section>
-        <section class="right-section">
-          <section class="third-row-right">
-            <p id="averageSleepOverall"></p>
-            <p id="sleepSpecificDay"></p>
-            <p id="sleepPerDayPerWeek"></p>
-          </section>
+        <header id="buttonHolder">
+            <button class="toggleButton">
+              <h3 class="arrow">&#x25BA;    User Info:</h3> 
+              <h3 class="user-info hidden"></h3>
+            </button>
+        </header>
         </section>
       </aside>
     <script src="bundle.js"></script>

--- a/src/styles.css
+++ b/src/styles.css
@@ -43,15 +43,16 @@ header {
   width: 20%;
   height: 100vh;
   background-color: #404348;
+  padding: 10px;
   margin: none;
 }
 
-#username,
-.right-section {
+#username {
   display: flex;
   justify-content: center;
   color: white;
   margin: 20px;
+  max-width: 100%;
 }
 
 .first-row-left {
@@ -59,8 +60,21 @@ header {
   flex-direction: column;
   align-items: center;
   border-radius: 10px;
-  height: 100%;
-  width: 100%;
+}
+
+.second-row-left {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  border-radius: 10px;
+}
+
+.first-row-left,
+.second-row-left {
+  width: 50vw;
+  height: 50vh;
+  margin: 30px;
 }
 
 #stepsBox {
@@ -78,26 +92,12 @@ header {
   display: flex;
   background-color: #054FB9;
   color: white;
-  /* height: 400px;
-  width: 450px; */
   box-shadow: 0px 0px 1.5px 2px white
-}
-
-.second-row-left {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  width: 50vw;
-  height: 35vh;
-  border-radius: 10px;
 }
 
 #activityBox {
   background-color: #0461cf;
   color: white;
-  /* height: 400px;
-  width: 380px; */
   box-shadow: 0px 0px 1.5px 2px white
 }
 
@@ -105,7 +105,6 @@ header {
   background-color: #B3C7F7;
   color: #01285e;
   padding: 10px;
-  /* height: 50%; */
   box-shadow: 0px 0px 1px 1px #01285e;
 }
 
@@ -116,14 +115,22 @@ header {
   font-family: "Gill Sans", sans-serif;
   font-size: 20px;
   border: none;
-  padding: 1vh 2vh;
+  padding: 10px;
   cursor: pointer;
   outline: none;
   border-radius: 10px;
+  max-width: 80%;
+  max-height: 100%;
 }
 
+.user-info,
 .arrow {
-  text-align: start;
+  text-align: center;
+}
+
+.user-info {
+  word-wrap: break-word;
+  max-height: 700px;
 }
 
 .hidden {
@@ -152,18 +159,13 @@ header {
 #waterBox,
 #activityBox,
 #sleepBox {
-  width: 50%;
-  height: 50%;
+  white-space: nowrap;
+  overflow-wrap: break-word;
+  width: 55%;
+  height: 30%;
 }
 
 #waterBox,
 #activityBox {
   padding: 20px;
-}
-
-.first-row-left,
-.second-row-left {
-  width: 50%;
-  height: 50%;
-  margin: 30px;
 }


### PR DESCRIPTION
✨ What I did:
-Got rid of overflow when username button is clicked. 
-when in normal mac size, steps paragraph no longer expands outside it's container
-removed unnecessary html and commented out css 
Did this break anything?

- [x] No
- [ ]  Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x]  Styling 
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:

- [x]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [x]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing


✨ What's next?
The styling now looks okay in a standard mac window but if you shrink the screen the steps paragraph still goes outside its container. Maybe someone else can take a look before the project is due tonight. Thanks!